### PR TITLE
Add workout import functionality and UI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: test clean build help
+
+help:
+	@echo "Usage:"
+	@echo "  make test    Run local unit tests"
+	@echo "  make clean   Clean build artifacts"
+	@echo "  make build   Build the debug APK"
+
+test:
+	./gradlew testDebugUnitTest
+
+clean:
+	./gradlew clean
+
+build:
+	./gradlew assembleDebug

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -33,13 +35,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose = true
     }
     buildToolsVersion = "36.1.0"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
 }
 
 dependencies {
@@ -67,6 +72,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.compose.ui.test.junit4)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,9 +35,17 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
     buildFeatures {
         compose = true
     }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+    
     buildToolsVersion = "36.1.0"
 }
 

--- a/app/src/main/java/com/alois/apollo/ui/MainScreen.kt
+++ b/app/src/main/java/com/alois/apollo/ui/MainScreen.kt
@@ -1,5 +1,8 @@
 package com.alois.apollo.ui
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,12 +17,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -37,6 +42,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,11 +60,22 @@ fun MainScreen(
 ) {
     val workouts by viewModel.availableWorkouts.collectAsState()
     val history by viewModel.history.collectAsState()
-    viewModel.isFrench()
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let { viewModel.importWorkout(context, it) }
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Apollo") })
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { launcher.launch("application/json") }) {
+                Icon(Icons.Default.Add, contentDescription = "Add Workout")
+            }
         }
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/test/java/com/alois/apollo/MainScreenTest.kt
+++ b/app/src/test/java/com/alois/apollo/MainScreenTest.kt
@@ -1,0 +1,32 @@
+package com.alois.apollo
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.alois.apollo.ui.MainScreen
+import com.alois.apollo.ui.theme.ApolloTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MainScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `MainScreen displays the add workout floating action button`() {
+        composeTestRule.setContent {
+            ApolloTheme {
+                MainScreen(onStartWorkout = {}, onViewSession = {})
+            }
+        }
+
+        // Verify that the floating action button with the add icon is present
+        composeTestRule.onNodeWithContentDescription("Add Workout").assertIsDisplayed()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
* Migrate Kotlin `jvmTarget` configuration to `compilerOptions`
* Enable Gradle configuration cache in `gradle.properties`
* Implement JSON workout import using `ActivityResultContracts.GetContent` and a Floating Action Button in `MainScreen`
* Add `androidx.compose.ui.test.junit4` dependency and a Robolectric-based UI test for `MainScreen`